### PR TITLE
Support block for each log method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: ruby
 rvm:
   - 2.1.0
   - 2.2.3
+  - 2.3.4
+  - 2.4.1
 before_install: gem install bundler -v 1.11.2

--- a/README.md
+++ b/README.md
@@ -144,6 +144,28 @@ end
 {"name":"main","hostname":"mint","pid":14607,"level":50,"time":"2016-10-16T22:26:48.836+09:00","v":0,"msg":"Caught error","err":{"name":"ZeroDivisionError","message":"divided by 0","stack":"main.rb:18:in `/'\n ...'"},"reason":"zero spec"}
 ```
 
+### logs with blocks
+
+```ruby
+logger.info { 'Hello!' }
+
+logger.debug do
+  ['User dump', { name: 'Taro', age: 15 }]
+end
+
+logger.error do
+  ['Failed to fetch info', ex, { id: 10 }]
+end
+
+loggger.fatal { ex }
+
+loggger.fatal do
+  ['Unexpected', ex]
+end
+```
+
+To specify more than one of a message, an exception and custom data, the block returns them as an array.
+
 
 ## View log by node-bunyan
 
@@ -205,7 +227,7 @@ A custom logger includes LoggerSilence because Rails logger must support `silenc
 ```ruby
 module YourApp
   class Logger < Ougai::Logger
-  	include ActiveSupport::LoggerThreadSafeLevel
+    include ActiveSupport::LoggerThreadSafeLevel
     include LoggerSilence
 
     def initialize(*args)

--- a/lib/ougai/logger.rb
+++ b/lib/ougai/logger.rb
@@ -12,24 +12,53 @@ module Ougai
       @formatter = create_formatter
     end
 
-    def debug(message, ex = nil, data = nil)
-      super(to_item(message, ex, data))
+    def debug(message = nil, ex = nil, data = nil, &block)
+      return true if level > DEBUG
+      if block_given?
+        args = yield
+      else
+        args = [message, ex, data]
+      end
+      super(to_item(args), &nil)
     end
 
-    def info(message, ex = nil, data = nil)
-      super(to_item(message, ex, data))
+    def info(message = nil, ex = nil, data = nil)
+      return true if level > INFO
+      if block_given?
+        args = yield
+      else
+        args = [message, ex, data]
+      end
+      super(to_item(args), &nil)
     end
 
-    def warn(message, ex = nil, data = nil)
-      super(to_item(message, ex, data))
+    def warn(message = nil, ex = nil, data = nil)
+      return true if level > WARN
+      if block_given?
+        args = yield
+      else
+        args = [message, ex, data]
+      end
+      super(to_item(args), &nil)
     end
 
-    def error(message, ex = nil, data = nil)
-      super(to_item(message, ex, data))
+    def error(message = nil, ex = nil, data = nil)
+      return true if level > ERROR
+      if block_given?
+        args = yield
+      else
+        args = [message, ex, data]
+      end
+      super(to_item(args), &nil)
     end
 
-    def fatal(message, ex = nil, data = nil)
-      super(to_item(message, ex, data))
+    def fatal(message = nil, ex = nil, data = nil)
+      if block_given?
+        args = yield
+      else
+        args = [message, ex, data]
+      end
+      super(to_item(args), &nil)
     end
 
     def self.broadcast(logger)
@@ -53,7 +82,9 @@ module Ougai
 
     private
 
-    def to_item(msg, ex, data)
+    def to_item(args)
+      msg, ex, data = args
+
       item = {}
       if ex.nil?       # 1 arg
         if msg.is_a?(Exception)

--- a/lib/ougai/version.rb
+++ b/lib/ougai/version.rb
@@ -1,3 +1,3 @@
 module Ougai
-  VERSION = "0.7.4"
+  VERSION = "0.8.0"
 end


### PR DESCRIPTION
* instead of #14 
* `message` or `[message, exception, data]` as the same method args
* Evaluate log level ahead to skip non-required logging and to avoid serializing