### PR TITLE
Bunyan formatter supports jsonize attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ougai
 [![Code Climate](https://codeclimate.com/github/tilfin/ougai/badges/gpa.svg)](https://codeclimate.com/github/tilfin/ougai)
 [![Test Coverage](https://codeclimate.com/github/tilfin/ougai/badges/coverage.svg)](https://codeclimate.com/github/tilfin/ougai/coverage)
 
-A JSON logging system is capable of handling a message, data or an exception easily.
+A structured JSON logging system is capable of handling a message, structured data or an exception easily.
 It is compatible with [Bunyan](https://github.com/trentm/node-bunyan) for Node.js.
 It can also output human readable format for the console.
 

--- a/README.md
+++ b/README.md
@@ -327,79 +327,6 @@ logger.formatter = Ougai::Formatters::Readable.new
 ![Screen Shot](https://github.com/tilfin/ougai/blob/images/ougai_readable_format.png?raw=true)
 
 
-## Use on Rails
-
-### Define a custom logger
-
-Add following code to `lib/your_app/logger.rb`
-A custom logger includes LoggerSilence because Rails logger must support `silence` feature.
-
-```ruby
-module YourApp
-  class Logger < Ougai::Logger
-    include ActiveSupport::LoggerThreadSafeLevel
-    include LoggerSilence
-
-    def initialize(*args)
-      super
-      after_initialize if respond_to? :after_initialize
-    end
-
-    def create_formatter
-      if Rails.env.development? || Rails.env.test?
-        Ougai::Formatters::Readable.new
-      else
-        Ougai::Formatters::Bunyan.new
-      end
-    end
-  end
-end
-```
-
-### for Development
-
-Add following code to `config/environments/development.rb`
-
-```ruby
-Rails.application.configure do
-  ...
-
-  config.logger = YourApp::Logger.new(STDOUT)
-end
-```
-
-### for Production
-
-Add following code to the end block of `config/environments/production.rb`
-
-```ruby
-Rails.application.configure do
-  ...
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    config.logger = YourApp::Logger.new(STDOUT)
-  else
-    config.logger = YourApp::Logger.new(config.paths['log'].first)
-  end
-end
-```
-
-### With Lograge
-
-You must modify [lograge](https://github.com/roidrage/lograge) formatter like *Raw*.
-The following code set request data to `request` field of JSON.
-
-```ruby
-Rails.application.configure do
-  config.lograge.enabled = true
-  config.lograge.formatter = Class.new do |fmt|
-    def fmt.call(data)
-      { msg: 'Request', request: data }
-    end
-  end
-end
-```
-
 ### Output example on development
 
 If you modify `application_controller.rb` as
@@ -437,6 +364,11 @@ logger outputs
     }
 }
 ```
+
+## How to use with famous products and libraries
+
+- [Use as Rails logger](https://github.com/tilfin/ougai/wiki/Use-as-Rails-logger)
+- [Customize Sidekiq logger](https://github.com/tilfin/ougai/wiki/Customize-Sidekiq-logger)
 
 ## License
 

--- a/lib/ougai/formatters/bunyan.rb
+++ b/lib/ougai/formatters/bunyan.rb
@@ -4,15 +4,22 @@ require 'json'
 module Ougai
   module Formatters
     class Bunyan < Base
+      attr_accessor :jsonize
+
+      def initialize
+        super
+        @jsonize = true
+      end
+
       def call(severity, time, progname, data)
-        JSON.generate({
+        dump({
           name: progname || @app_name,
           hostname: @hostname,
           pid: $$,
           level: to_level(severity),
-          time: time.iso8601(3),
+          time: time,
           v: 0
-        }.merge(data)) + "\n"
+        }.merge(data))
       end
 
       def to_level(severity)
@@ -30,6 +37,14 @@ module Ougai
         else # DEBUG
           20
         end
+      end
+
+      private
+
+      def dump(data)
+        return data unless @jsonize
+        data[:time] = data[:time].iso8601(3)
+        JSON.generate(data) + "\n"
       end
     end
   end

--- a/lib/ougai/version.rb
+++ b/lib/ougai/version.rb
@@ -1,3 +1,3 @@
 module Ougai
-  VERSION = "1.4.1"
+  VERSION = "1.4.2"
 end

--- a/spec/formatters/bunyan_spec.rb
+++ b/spec/formatters/bunyan_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+describe Ougai::Formatters::Bunyan do
+  let(:data) do
+    {
+      msg: 'Log Message!',
+      status: 200,
+      method: 'GET',
+      path: '/'
+    }
+  end
+
+  let(:err) do
+    {
+      name: 'DummyError',
+      message: 'it is dummy.',
+      stack: "error1.rb\n  error2.rb"
+    }
+  end
+
+  let(:formatter) { described_class.new }
+
+  context 'when severity is DEBUG' do
+    subject { JSON.parse(formatter.call('DEBUG', Time.now, nil, data).chomp, symbolize_names: true) }
+
+    it 'includes valid strings' do
+      expect(subject).to include(data.merge(level: 20))
+      expect(subject[:time]).to match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+    end
+  end
+
+  context 'jsonize is falsey' do
+    before do
+      formatter.jsonize = false
+    end
+
+    context 'when severity is DEBUG' do
+      subject { formatter.call('DEBUG', Time.now, nil, data) }
+
+      it 'includes valid hash' do
+        expect(subject).to include(data.merge(level: 20))
+        expect(subject[:time]).to be_an_instance_of(Time)
+      end
+    end
+
+    context 'when severity is INFO' do
+      subject { formatter.call('INFO', Time.now, nil, data) }
+
+      it 'includes valid hash' do
+        expect(subject).to include(data.merge(level: 30))
+        expect(subject[:time]).to be_an_instance_of(Time)
+      end
+    end
+
+    context 'when severity is WARN' do
+      subject { formatter.call('WARN', Time.now, nil, data) }
+
+      it 'includes valid hash' do
+        expect(subject).to include(data.merge(level: 40))
+        expect(subject[:time]).to be_an_instance_of(Time)
+      end
+    end
+
+    context 'when severity is ERROR' do
+      subject { formatter.call('ERROR', Time.now, nil, data.merge({ err: err })) }
+
+      it 'includes valid hash' do
+        expect(subject).to include(level: 50, err: err)
+        expect(subject[:time]).to be_an_instance_of(Time)
+      end
+    end
+
+    context 'when severity is FATAL' do
+      subject { formatter.call('FATAL', Time.now, nil, { msg: 'TheEnd', err: err }) }
+
+      it 'includes valid hash' do
+        expect(subject).to include(level: 60, err: err)
+        expect(subject[:time]).to be_an_instance_of(Time)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- `formatter.jsonize = true` is default to dump as json.
- `jsonize = false` is passing to a logdevice as hash.
- for 1.4.1