### PR TITLE
Fix logging without arguments

### DIFF
--- a/lib/ougai/logger.rb
+++ b/lib/ougai/logger.rb
@@ -91,14 +91,14 @@ module Ougai
     def to_item(args)
       msg, ex, data = args
 
-      if ex.nil?
+      if msg.nil?
+        { msg: @default_message }
+      elsif ex.nil?
         create_item_with_1arg(msg)
       elsif data.nil?
         create_item_with_2args(msg, ex)
-      elsif msg
+      else
         create_item_with_3args(msg, ex, data)
-      else # No args
-        { msg: @default_message }
       end
     end
 

--- a/lib/ougai/version.rb
+++ b/lib/ougai/version.rb
@@ -1,3 +1,3 @@
 module Ougai
-  VERSION = "1.5.2"
+  VERSION = "1.5.3"
 end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -230,6 +230,13 @@ describe Ougai::Logger do
         expect(item).to include_data(something: { name: 'foo' })
       end
     end
+
+    context 'without arguments' do
+      it 'outputs only default message' do
+        logger.send(method)
+        expect(item).to be_log_message('No message', log_level)
+      end
+    end
   end
 
   describe '#trace' do


### PR DESCRIPTION
The message is empty not default if logger `info` no arguments.