### PR TITLE
Fix initialize in bunyan formatter

### DIFF
--- a/lib/ougai/formatters/bunyan.rb
+++ b/lib/ougai/formatters/bunyan.rb
@@ -9,8 +9,8 @@ module Ougai
     class Bunyan < Base
       attr_accessor :jsonize, :with_newline
 
-      def initialize
-        super
+      def initialize(*args)
+        super(*args)
         @jsonize = true
         @with_newline = true
       end

--- a/spec/formatters/bunyan_spec.rb
+++ b/spec/formatters/bunyan_spec.rb
@@ -20,6 +20,15 @@ describe Ougai::Formatters::Bunyan do
 
   let(:formatter) { described_class.new }
 
+  context '#initialize' do
+    let(:appname) { 'dummy app name' }
+
+    it 'suceeds with arguments' do
+      fmt = described_class.new(appname)
+      expect(fmt.app_name).to eq(appname)
+    end
+  end
+
   context 'jsonize is true and with_newline is true' do
     subject { formatter.call('DEBUG', Time.now, nil, data) }
 


### PR DESCRIPTION
The initializer does not receive arguments.
release for v1.5.6
