### PR TITLE
Fix Formatter#call when logger#add with string directly

### DIFF
--- a/lib/ougai/formatters/base.rb
+++ b/lib/ougai/formatters/base.rb
@@ -4,6 +4,7 @@ require 'socket'
 module Ougai
   module Formatters
     # Base formatter
+    # Custom formatter must override `_call`.
     # @attr [Fixnum] trace_indent Specify exception backtrace indent (by default this is 2).
     # @attr [Fixnum] trace_max_lines Keep exception backtrace lines (by default this is 100).
     # @attr [Boolean] serialize_backtrace Whether exception should converts String (by default this is on).
@@ -19,6 +20,14 @@ module Ougai
         @trace_max_lines = 100
         @serialize_backtrace = true
         self.datetime_format = nil
+      end
+
+      def call(severity, time, progname, data)
+        _call(severity, time, progname, data.is_a?(Hash) ? data : { msg: data.to_s })
+      end
+
+      def _call(severity, time, progname, data)
+        raise NotImplementedError, "_call must be implemented"
       end
 
       def datetime_format=(value)

--- a/lib/ougai/formatters/bunyan.rb
+++ b/lib/ougai/formatters/bunyan.rb
@@ -15,7 +15,7 @@ module Ougai
         @with_newline = true
       end
 
-      def call(severity, time, progname, data)
+      def _call(severity, time, progname, data)
         dump({
           name: progname || @app_name,
           hostname: @hostname,

--- a/lib/ougai/formatters/readable.rb
+++ b/lib/ougai/formatters/readable.rb
@@ -18,7 +18,7 @@ module Ougai
         load_dependent
       end
 
-      def call(severity, time, progname, data)
+      def _call(severity, time, progname, data)
         msg = data.delete(:msg)
         level = @plain ? severity : colored_level(severity)
         dt = format_datetime(time)


### PR DESCRIPTION
Fix #45 on v1.5.8

Several middlewares or hook loggers may call logger#add with data as string directly.