### PR TITLE
Readable formatter customization: subformatter & colorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,8 @@ my_formatter = Ougai::Formatters::Readable.new(
 logger = Ougai::Logger.new
 logger.formatter = my_formatter
 ```
-
+Such configuration, along with Lograge, makes the logs looking like:
+![Screenshot](https://github.com/Al-un/ougai/blob/images/ougai_readable_formatter_colorization_custom.png)
 
 ## How to use with famous products, services and libraries
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,8 @@ logger.formatter = Ougai::Formatters::Readable.new
 You can assign three custom *sub-formatters*:
   - **`msg_formatter`** to format the main log line (usually datetime, log level 
     and main message). This formatter must have a `call` method responding to
-    the signature `call(datetime, severity, msg, progname, data)`. 
+    the signature `call(severity, datetime, progname, data)`. Main log message has
+    to be extracted from data: `msg = data.delete(:msg)` 
 
     Default  value is an instance of *Ougai::Formatters::Readable::MessageFormatter*
   - **`data_formatter`** to format the structured logs. The `call` method must 

--- a/lib/ougai/colors.rb
+++ b/lib/ougai/colors.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Ougai
+  # List of available foreground and background colors along with font modifier.
+  #
+  # Non-bold font colors do not use \e[0;{value}m because it seems to be
+  # incompatible with background colors: \e[41m\e[0;34mtext\e[0m does not print
+  # background red while \e[41m\e[34mtext\e[0m works. However, to put font in
+  # bold/bright mode, \e[41m\e[1;34mtext\e[0m works
+  # => Tested on Windows PowerShell and MinGW64
+  #
+  # Source: https://gist.github.com/chrisopedia/8754917
+  module Colors
+    # Reset formatting. To be appended after every formatted text
+    RESET             = "\e[0m" 
+    # Foreground colors
+    BLACK             = "\e[30m"
+    RED               = "\e[31m"
+    GREEN             = "\e[32m"
+    YELLOW            = "\e[33m"
+    BLUE              = "\e[34m"
+    PURPLE            = "\e[35m"
+    CYAN              = "\e[36m"
+    WHITE             = "\e[37m"
+    BOLD_RED          = "\e[1;31m"
+    BOLD_GREEN        = "\e[1;32m"
+    BOLD_YELLOW       = "\e[1;33m"
+    BOLD_BLUE         = "\e[1;34m"
+    BOLD_MAGENTA      = "\e[1;35m"
+    BOLD_CYAN         = "\e[1;36m"
+    BOLD_WHITE        = "\e[1;37m"
+    # Background colors
+    BG_BLACK          = "\e[40m"
+    BG_RED            = "\e[41m"
+    BG_GREEN          = "\e[42m"
+    BG_YELLOW         = "\e[43m"
+    BG_BLUE           = "\e[44m"
+    BG_MAGENTA        = "\e[45m"
+    BG_CYAN           = "\e[46m"
+    BG_WHITE          = "\e[47m"
+
+    class << self
+      # Color a text
+      # @param [String] color: color to prepend. Color can be from the list
+      #         above or have a complete custom value depending on the terminal
+      # @param [String] text: text to be colored
+      def color_text(color, text)
+        return text if color.nil?
+
+        color + text + Ougai::Colors::RESET
+      end
+    end
+
+  end
+end

--- a/lib/ougai/colors/configuration.rb
+++ b/lib/ougai/colors/configuration.rb
@@ -1,0 +1,91 @@
+require 'ougai/colors'
+
+module Ougai
+  module Colors
+    # Handle the colorization of output, mainly aimed at console formatting. The
+    # configuration is split by subject such as +level+, +msg+, or +datetime+.
+    class Configuration
+
+      class << self
+
+        # Returns the default Ougai color configuration
+        # 'any' severity label decided in Ougai::Logging::Severity#to_label
+        def default_configuration
+          {
+            severity: {
+              trace:  Ougai::Colors::BLUE,
+              debug:  Ougai::Colors::WHITE,
+              info:   Ougai::Colors::CYAN,
+              warn:   Ougai::Colors::YELLOW,
+              error:  Ougai::Colors::RED,
+              fatal:  Ougai::Colors::PURPLE,
+              any:    Ougai::Colors::GREEN
+            }
+          }
+        end
+
+      end
+
+      # @param [Hash] configuration: Color configuration. Cannot be nil
+      def initialize(configuration = {})
+        # key = subject (datetime, msg, level...) and value is a String
+        # representing the ANSI color code. String value is not checked
+        # so custom colors are allowed but subject to console incompatibility
+        @config = Configuration.default_configuration
+
+        configuration.each do |key, val|
+          default_val = @config[key]
+          # default value is a Hash AND input value is a Hash => merge
+          if val.is_a?(Hash) && default_val.is_a?(Hash)
+            @config[key] = default_val.merge(val)
+          # Input value is assigned because one of the follow
+          # 1) input value is not defined in default configuration
+          # 2) input value is not a Hash which overrides the default value
+          # 3) default value is not a Hash and input is a Hash => Arbitrary design
+          else
+            @config[key] = val
+          end
+        end
+      end
+
+      # Return a colored text depending on the subject
+      # @param [Symbol] subject_key: to define the color to color the text
+      # @param [String] text: to be colored text
+      # @param [Symbol] severity: log level
+      def color(subject_key, text, severity)
+        color = get_color_for(subject_key, severity)
+        Ougai::Colors.color_text(color, text)
+      end
+
+      # Return the color for a given suject and a given severity. This color can
+      # then be applied to any text via Ougai::Colors.color_text
+      #
+      # get_color_for handles color inheritance: if a subject inherit color from
+      # another subject, subject value is the symbol refering to the other
+      # subject. 
+      # !!WARNING!!: Circular references are not checked and lead to infinite loop  
+      #
+      # @param [Symbol] subject_key: to define the color to color the text
+      # @param [Symbol] severity: log level
+      # @return requested color String value or +nil+ if not colored
+      def get_color_for(subject_key, severity)
+        # no colorization
+        return nil unless @config.key?(subject_key)
+        
+        # no severity dependence nor inheritance
+        color = @config[subject_key]
+        return color if color.is_a? String
+
+        # inheritance from another subject
+        return get_color_for(color, severity) if color.is_a? Symbol
+
+        # severity dependent but not inherited value or return +nil+ if
+        # configuration is incorrect
+        severity = severity.downcase.to_sym
+        color[severity]
+      end
+
+    end
+
+  end
+end

--- a/lib/ougai/formatters/readable.rb
+++ b/lib/ougai/formatters/readable.rb
@@ -54,13 +54,11 @@ module Ougai
       def _call(severity, time, progname, data)
         strs = []
         # Main message
-        msg = data.delete(:msg)
         dt = format_datetime(time)
-        strs << @msg_formatter.call(dt, severity, msg, progname, data)
+        strs << @msg_formatter.call(severity, dt, progname, data)
 
         # Error: displayed before additional data
         if data.key?(:err)
-          err = 
           err_str = @err_formatter.call(data)
           strs.push(err_str)
         end
@@ -98,12 +96,12 @@ module Ougai
           @plain = plain
         end
 
-        # @param [String] datetime: formatted uncolored datetime
         # @param [String] severity: unformatted uncolored severity
-        # @param [String] msg: main log message
+        # @param [String] datetime: formatted uncolored datetime
         # @param [String] _progname: optional program name
-        # @param [Hash] _data: additional data
-        def call(datetime, severity, msg, _progname, _data)
+        # @param [Hash] data: data containing :msg
+        def call(severity, datetime, _progname, data)
+          msg = data.delete(:msg)
           # optional colorization
           unless @plain
             severity = @color_config.color(:severity, severity, severity)

--- a/spec/colors/configuration_spec.rb
+++ b/spec/colors/configuration_spec.rb
@@ -1,0 +1,165 @@
+require 'spec_helper'
+require 'ougai/colors/configuration'
+require 'ougai/logging'
+
+describe Ougai::Colors::Configuration do
+  let(:default_cfg) { Ougai::Colors::Configuration.default_configuration }
+  let(:trace)       { 'TRACE' }
+  let(:debug)       { 'DEBUG' }
+  let(:info)        { 'INFO' }
+  let(:warn)        { 'WARN' }
+  let(:error)       { 'ERROR' }
+  let(:fatal)       { 'FATAL' }
+  let(:any)         { 'ANY' }
+  let(:severities)  { [trace, debug, info, warn, error, fatal, any] }
+  let(:severities_sym) { [:trace, :debug, :info, :warn, :error, :fatal, :any] }
+
+  describe 'default configuration' do
+    it 'handles all severities' do
+      expect(default_cfg[:severity]).to be_a(Hash)
+      severities_sym.each do |level|
+        # Ensure value is present. Value is not checked
+        expect(default_cfg[:severity][level]).to be_a(String)
+      end
+    end
+  end
+
+  context 'with no configuration input' do
+    subject { Ougai::Colors::Configuration.new }
+
+    describe '#initialize' do
+      it 'has default configuration' do
+        expect(subject.instance_variable_get(:@config)).to eq(default_cfg)
+      end
+    end
+  end
+
+  context 'with a complete configuration' do
+    let(:input_cfg) do
+      {
+        severity: {
+          trace: 'some_value', debug: 'some_value', info: 'some_value',
+          warn: 'some_value', error: 'some_value', fatal: 'some_value',
+          any: 'some_value'
+        },
+        datetime: 'some color',
+        msg: {
+          trace: 'trace_value', debug: 'debug_value', info: 'info_value',
+          warn: 'warn_value', error: 'error_value', fatal: 'fatal_value',
+          any: 'any_value'
+        }
+      }
+    end
+    subject { Ougai::Colors::Configuration.new(input_cfg) }
+
+    describe '#initialize' do
+      it 'has input as configuration' do
+        expect(subject.instance_variable_get(:@config)).to eq(input_cfg)
+      end
+    end
+
+    describe '#get_color_for' do
+      context 'with a String value' do
+        it 'returns the single value regardless severity' do
+          severities.each do |lvl|
+            expect(subject.get_color_for(:datetime, lvl)).to eq('some color')
+          end
+        end
+      end
+      context 'with a Hash value' do
+        it 'returns the single value depending on severity' do
+          severities.each do |lvl|
+            expect(subject.get_color_for(:msg, lvl)).to eq(lvl.downcase + '_value')
+          end
+        end
+      end
+    end
+  end
+
+  context 'with a configuration with inheritance' do
+    let(:input_cfg) do
+      # datetime should refer to :severity for optimum but for the sake of testing
+      { msg: :severity, datetime: :msg}
+    end
+    subject { Ougai::Colors::Configuration.new(input_cfg) }
+
+    describe '#get_color_for' do
+      it 'takes inherited color (direct inheritance)' do
+        severities.each do |lvl|
+          expect(subject.get_color_for(:msg, lvl)).to eq(subject.get_color_for(:severity, lvl))
+        end
+      end
+      it 'takes inherited color (two-levels inheritance)' do
+        severities.each do |lvl|
+          expect(subject.get_color_for(:datetime, lvl)).to eq(subject.get_color_for(:severity, lvl))
+        end
+      end
+    end
+
+  end
+
+  context 'with an severity color' do
+    let(:uniq_value) { 'an unique color' }
+    subject { Ougai::Colors::Configuration.new(severity: uniq_value) }
+    let(:cfg) { subject.instance_variable_get(:@config) }
+
+    describe '.initialize' do
+      it 'has severity configuration reduced to a single value' do
+        expect(cfg[:severity]).to be_a(String)
+        expect(cfg[:severity]).to eq(uniq_value)
+      end
+    end
+
+    describe '#get_color_for' do
+      it 'returns the same severity value regardless severity' do
+        severities.each do |lvl|
+          expect(subject.get_color_for(:severity, lvl)).to eq(uniq_value)
+        end
+      end
+    end
+  end
+
+  context 'without severity configuration' do
+    let(:input_cfg) do
+      { datetime: :severity, msg: 'some irrelevant value' }
+    end
+    subject { Ougai::Colors::Configuration.new(input_cfg) }
+    let(:cfg) { subject.instance_variable_get(:@config) }
+
+    describe '#initialize' do
+      it 'has default severity values' do
+        expect(cfg[:severity]).to eq(default_cfg[:severity])
+      end
+
+      it 'has input values' do
+        expect(cfg[:datetime]).to eq(input_cfg[:datetime])
+        expect(cfg[:msg]).to eq(input_cfg[:msg])
+      end
+    end
+  end
+
+  context 'with partial severity configuration' do
+    let(:input_cfg) { { severity: { info: 'some_value', warn: 'some_value' }} }
+    subject         { Ougai::Colors::Configuration.new(input_cfg) }
+    let(:cfg)       { subject.instance_variable_get(:@config) }
+
+    describe '#initialize' do
+      it 'takes values undefined in default from input' do
+        expect(cfg[:datetime]).to eq(input_cfg[:datetime])
+      end
+
+      it 'has input values having precedence over default values' do
+        expect(cfg[:severity][:info]).to eq(input_cfg[:severity][:info])
+        expect(cfg[:severity][:warn]).to eq(input_cfg[:severity][:warn])
+      end
+
+      it 'takes values undefined in input from default' do
+        expect(cfg[:severity][:trace]).to eq(default_cfg[:severity][:trace])
+        expect(cfg[:severity][:debug]).to eq(default_cfg[:severity][:debug])
+        expect(cfg[:severity][:error]).to eq(default_cfg[:severity][:error])
+        expect(cfg[:severity][:fatal]).to eq(default_cfg[:severity][:fatal])
+      end
+    end
+  end
+
+end

--- a/spec/colors_spec.rb
+++ b/spec/colors_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'ougai/colors'
+
+describe Ougai::Colors do
+
+  describe '#color_text' do
+    let(:dummy_text) { 'some dummy text' }
+  
+    context 'color is nil' do
+      it 'raw text is returned' do
+        uncolored_text = Ougai::Colors.color_text(nil, dummy_text)
+        expect(uncolored_text).to eq(dummy_text)
+      end
+    end
+
+    context 'color is provided' do
+      it 'text is properly colored' do
+        colored_text = Ougai::Colors.color_text(Ougai::Colors::RED, dummy_text)
+        expect(colored_text).to eq(Ougai::Colors::RED + dummy_text + Ougai::Colors::RESET)
+      end
+    end
+  end
+
+end

--- a/spec/formatters/readable_spec.rb
+++ b/spec/formatters/readable_spec.rb
@@ -2,6 +2,13 @@ require 'spec_helper'
 
 describe Ougai::Formatters::Readable do
   let!(:re_start_with_datetime) { /^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}(Z|[\+\-\:0-9]{4,6})]/ }
+  let!(:trace_color)    { "\e[34m" }
+  let!(:debug_color)    { "\e[37m" }
+  let!(:info_color)     { "\e[36m" }
+  let!(:warn_color)     { "\e[33m" }
+  let!(:error_color)    { "\e[31m" }
+  let!(:fatal_color)    { "\e[35m" }
+  let!(:unknown_color)  { "\e[32m" }
 
   let(:data) do
     {
@@ -35,12 +42,26 @@ describe Ougai::Formatters::Readable do
       excluded_fields: [:card_number]
     }
 
+  describe '#initialize' do
+    context 'when no custom sub-formatter' do 
+      it 'has the default message formatter' do
+        expect(subject.instance_variable_get(:@msg_formatter)).to be_a(Ougai::Formatters::Readable::MessageFormatter)
+      end
+      it 'has the default data formatter' do
+        expect(subject.instance_variable_get(:@data_formatter)).to be_a(Ougai::Formatters::Readable::DataFormatter)
+      end
+      it 'has the default error formatter' do
+        expect(subject.instance_variable_get(:@err_formatter)).to be_a(Ougai::Formatters::Readable::ErrorFormatter)
+      end
+    end
+  end
+
   context 'when severity is TRACE' do
     subject { formatter.call('TRACE', Time.now, nil, data) }
 
     it 'includes valid strings' do
       expect(subject).to match(re_start_with_datetime)
-      expect(subject).to include("\e[0;34mTRACE\e[0m: Log Message!")
+      expect(subject).to include("#{trace_color}TRACE\e[0m: Log Message!")
       expect(subject.gsub(/\e\[([;\d]+)?m/, '')).to include(':status => 200')
     end
   end
@@ -50,7 +71,7 @@ describe Ougai::Formatters::Readable do
 
     it 'includes valid strings' do
       expect(subject).to match(re_start_with_datetime)
-      expect(subject).to include("\e[0;37mDEBUG\e[0m: Log Message!")
+      expect(subject).to include("#{debug_color}DEBUG\e[0m: Log Message!")
       expect(subject.gsub(/\e\[([;\d]+)?m/, '')).to include(':status => 200')
     end
   end
@@ -60,7 +81,7 @@ describe Ougai::Formatters::Readable do
 
     it 'includes valid strings' do
       expect(subject).to match(re_start_with_datetime)
-      expect(subject).to include("\e[0;36mINFO\e[0m: Log Message!")
+      expect(subject).to include("#{info_color}INFO\e[0m: Log Message!")
       expect(subject.gsub(/\e\[([;\d]+)?m/, '')).to include(':method => "GET"')
     end
   end
@@ -70,7 +91,7 @@ describe Ougai::Formatters::Readable do
 
     it 'includes valid strings' do
       expect(subject).to match(re_start_with_datetime)
-      expect(subject).to include("\e[0;33mWARN\e[0m: Log Message!")
+      expect(subject).to include("#{warn_color}WARN\e[0m: Log Message!")
       expect(subject.gsub(/\e\[([;\d]+)?m/, '')).to include(':path => "/"')
     end
   end
@@ -80,7 +101,7 @@ describe Ougai::Formatters::Readable do
 
     it 'includes valid strings' do
       expect(subject).to match(re_start_with_datetime)
-      expect(subject).to include("\e[0;31mERROR\e[0m: Log Message!")
+      expect(subject).to include("#{error_color}ERROR\e[0m: Log Message!")
       expect(subject.gsub(/\e\[([;\d]+)?m/, '')).to include('DummyError (it is dummy.):')
     end
   end
@@ -90,7 +111,7 @@ describe Ougai::Formatters::Readable do
 
     it 'includes valid strings' do
       expect(subject).to match(re_start_with_datetime)
-      expect(subject).to include("\e[0;35mFATAL\e[0m: TheEnd")
+      expect(subject).to include("#{fatal_color}FATAL\e[0m: TheEnd")
       expect(subject.gsub(/\e\[([;\d]+)?m/, '')).to include("error1.rb\n  error2.rb")
     end
   end
@@ -100,7 +121,7 @@ describe Ougai::Formatters::Readable do
 
     it 'includes valid strings' do
       expect(subject).to match(re_start_with_datetime)
-      expect(subject).to include("\e[0;32mANY\e[0m: unknown msg")
+      expect(subject).to include("#{unknown_color}ANY\e[0m: unknown msg")
     end
   end
 
@@ -110,7 +131,7 @@ describe Ougai::Formatters::Readable do
     end
 
     it 'includes valid strings' do
-      expect(subject).to include("\e[0;37mDEBUG\e[0m: Log Message!")
+      expect(subject).to include("#{debug_color}DEBUG\e[0m: Log Message!")
       plain_subject = subject.gsub(/\e\[([;\d]+)?m/, '')
       expect(plain_subject).to include(':path => "/"')
       expect(plain_subject).not_to include(':status => 200')


### PR DESCRIPTION
First of all, thank you for Ougai! I really like it. Relying a lot on console logs, two points bothered me a bit:
- colorization customization
- control over formatting in the console.

This PR is then a suggestion to address those points.

**Formatting**
While structured logs is easy to JSON-ed, it is not obvious for console rendering, especially when coupled with Lograge. Having a long Hash over multiple lines kind of kills Lograge primary purpose: reducing log output size

To solve it, I suggest splitting *Readable* into three sub-formatters:
- `msg_formatter` for the main log message (default format is `[{datetime}] {severity}: {msg}`). This sub formatters also takes `data` in argument so that it can optionally render some data as well. Especially useful for Lograge.
- `data_formatter` for the structured log part. While the `excluded_field` is a good point for reducing log output, it does not allow conditional exclusions. In my case, I would have a special formatting for Lograge/Lograge-sql logs (a way to identify Lograge logs cannot be configured in Ougai) and for everything else, I use awesome print.
- `err_formatter`. Honestly speaking... it is only for the sake of harmonization (everything is calling a sub-formatter) but I don't think errors need a lot of customization

**Colorization**

I like when log entries colorization depends on severity. To me, it is more a luxury compared to formatting but I find it comfortable to have it that way. Color configuration is basically a Hash *:key => :color* offering three possibilities:
1. a single color independent from log severity
2. a color for each severity
3. a reference to another key: this key will copy the color from the referenced key

**Replace Readable or create a new Formatter?**

I hesitated a lot on that point. I was afraid as I add additional checks/method that my formatter would slow down logging so I initially wanted to created another formatter *Colored* or *Customizable*. However, the default configuration is exactly the current `Readable` configuration so my *Readable* extends the existing *Readable* hence my final choice to override the existing *Readable*

<sub>And thank you for clapping my Medium article ^^</sub>
