### PR TITLE
Fix deprecation warning on Ruby 2.7

### DIFF
--- a/lib/ougai/logger.rb
+++ b/lib/ougai/logger.rb
@@ -11,8 +11,8 @@ module Ougai
 
     attr_accessor :default_message, :exc_key
 
-    def initialize(*args)
-      super(*args)
+    def initialize(*, **)
+      super
       @before_log = nil
       @default_message = 'No message'
       @exc_key = :err


### PR DESCRIPTION
The `Logger` constructor takes keyword arguments, but the `Ougai::Logger` subclass only takes positional arguments. This relies on the now-deprecated behaviour that if the last argument to a method is a hash it can be used as keyword arguments, so it generates a warning on Ruby 2.7:

```
~/lib/ougai/logger.rb:15: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
~/.rubies/ruby-2.7.1/lib/ruby/2.7.0/logger.rb:379: warning: The called method `initialize' is defined here
```

This PR fixes the deprecation warning by specifying that the constructor can take both positional and keyword arguments, and passing all arguments through to the superclass constructor.