### PR TITLE
Fix the compatibility with ActiveSupport::LoggerThreadSafeLevel

### DIFF
--- a/lib/ougai/logger.rb
+++ b/lib/ougai/logger.rb
@@ -39,8 +39,8 @@ module Ougai
     # @param logger [Logger] The logger receiving broadcast logs.
     def self.broadcast(logger)
       Module.new do |mdl|
-        define_method(:add) do |*args, &block|
-          logger.add(*args, &block)
+        define_method(:_log) do |*args, &block|
+          logger._log(*args, &block)
           super(*args, &block)
         end
 

--- a/lib/ougai/logging.rb
+++ b/lib/ougai/logging.rb
@@ -28,7 +28,7 @@ module Ougai
     # @return [Boolean] true
     # @see Logging#debug
     def trace(message = nil, ex = nil, data = nil, &block)
-      add(TRACE, message, ex, data, &block)
+      _log(TRACE, message, ex, data, &block)
     end
 
     # Log any one or more of a message, an exception and structured data as DEBUG.
@@ -39,42 +39,42 @@ module Ougai
     # @yieldreturn [String|Exception|Object|Array] Any one or more of former parameters
     # @return [Boolean] true
     def debug(message = nil, ex = nil, data = nil, &block)
-      add(DEBUG, message, ex, data, &block)
+      _log(DEBUG, message, ex, data, &block)
     end
 
     # Log any one or more of a message, an exception and structured data as INFO.
     # @return [Boolean] true
     # @see Logging#debug
     def info(message = nil, ex = nil, data = nil, &block)
-      add(INFO, message, ex, data, &block)
+      _log(INFO, message, ex, data, &block)
     end
 
     # Log any one or more of a message, an exception and structured data as WARN.
     # @return [Boolean] true
     # @see Logging#debug
     def warn(message = nil, ex = nil, data = nil, &block)
-      add(WARN, message, ex, data, &block)
+      _log(WARN, message, ex, data, &block)
     end
 
     # Log any one or more of a message, an exception and structured data as ERROR.
     # @return [Boolean] true
     # @see Logging#debug
     def error(message = nil, ex = nil, data = nil, &block)
-      add(ERROR, message, ex, data, &block)
+      _log(ERROR, message, ex, data, &block)
     end
 
     # Log any one or more of a message, an exception and structured data as FATAL.
     # @return [Boolean] true
     # @see Logging#debug
     def fatal(message = nil, ex = nil, data = nil, &block)
-      add(FATAL, message, ex, data, &block)
+      _log(FATAL, message, ex, data, &block)
     end
 
     # Log any one or more of a message, an exception and structured data as UNKNOWN.
     # @return [Boolean] true
     # @see Logging#debug
     def unknown(message = nil, ex = nil, data = nil, &block)
-      add(UNKNOWN, message, ex, data, &block)
+      _log(UNKNOWN, message, ex, data, &block)
     end
 
     # Whether the current severity level allows for logging TRACE.
@@ -91,13 +91,17 @@ module Ougai
     # @param data [Object] Any structured data
     # @yieldreturn [String|Exception|Object|Array] Any one or more of former parameters
     # @return [Boolean] true
-    def add(severity, *args)
-      severity ||= UNKNOWN
-      return true if level > severity
-      append(severity, block_given? ? yield : args)
+    def add(severity, message = nil, ex = nil, data = nil, &block)
+      _log(severity, message, ex, data, &block)
     end
 
     alias log add
+
+    def _log(severity, message, ex, data, &block)
+      severity ||= UNKNOWN
+      return true if level > severity
+      append(severity, block_given? ? yield : [message, ex, data])
+    end
 
     # @private
     def chain(_severity, _args, _fields, _hooks)

--- a/lib/ougai/logging.rb
+++ b/lib/ougai/logging.rb
@@ -97,10 +97,10 @@ module Ougai
 
     alias log add
 
-    def _log(severity, message, ex, data, &block)
+    def _log(severity, *args)
       severity ||= UNKNOWN
       return true if level > severity
-      append(severity, block_given? ? yield : [message, ex, data])
+      append(severity, block_given? ? yield : args)
     end
 
     # @private

--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -54,10 +54,18 @@ describe Ougai::Logging do
       end
     end
 
-    context 'block given' do
-      it 'calls append with yielded arguments' do
-        expect(subject).to receive(:append).with(::Logger::Severity::WARN, ['block message'])
-        subject.log(::Logger::Severity::WARN) { ['block message'] }
+    context 'with block that yields message' do
+      it 'calls append with yielded message' do
+        expect(subject).to receive(:append).with(::Logger::Severity::WARN, 'block message')
+        subject.add(::Logger::Severity::WARN) { 'block message' }
+      end
+    end
+
+    context 'with block that yields array' do
+      it 'calls append with yielded array' do
+        data = double('data')
+        expect(subject).to receive(:append).with(::Logger::Severity::WARN, ['block message', data])
+        subject.add(::Logger::Severity::WARN) { ['block message', data] }
       end
     end
   end
@@ -78,7 +86,7 @@ describe Ougai::Logging do
       end
     end
 
-    context 'block given' do
+    context 'with block' do
       it 'calls append with yielded arguments' do
         ex = Exception.new
         data = double('data')

--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -42,14 +42,14 @@ describe Ougai::Logging do
     context 'severity is specified level' do
       it 'calls append with specified level' do
         data = double('data')
-        expect(subject).to receive(:append).with(::Logger::Severity::DEBUG, ['debug message', data])
+        expect(subject).to receive(:append).with(::Logger::Severity::DEBUG, ['debug message', data, nil])
         subject.add(::Logger::Severity::DEBUG, 'debug message', data)
       end
     end
 
     context 'severity is nil' do
       it 'calls append with UNKNOWN level' do
-        expect(subject).to receive(:append).with(::Logger::Severity::UNKNOWN, ['message'])
+        expect(subject).to receive(:append).with(::Logger::Severity::UNKNOWN, ['message', nil, nil])
         subject.add(nil, 'message')
       end
     end
@@ -66,14 +66,14 @@ describe Ougai::Logging do
     context 'severity is specified' do
       it 'calls append with specified level' do
         ex = Exception.new
-        expect(subject).to receive(:append).with(::Logger::Severity::FATAL, ['fatal message', ex])
+        expect(subject).to receive(:append).with(::Logger::Severity::FATAL, ['fatal message', ex, nil])
         subject.log(::Logger::Severity::FATAL, 'fatal message', ex)
       end
     end
 
     context 'severity is nil' do
       it 'calls append with UNKNOWN level' do
-        expect(subject).to receive(:append).with(::Logger::Severity::UNKNOWN, ['message'])
+        expect(subject).to receive(:append).with(::Logger::Severity::UNKNOWN, ['message', nil, nil])
         subject.log(nil, 'message')
       end
     end


### PR DESCRIPTION
#114 

- introduces `_log` method to avoid using `add` method directly