### PR TITLE
Merge hash fields recursively for additional fields and child logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,18 @@ logger.info('Hello!', user: { name: 'Jiro' }, version: '2.3')
 ```
 
 If any field of with_fields is specified in each log, the field is overridden.
-But if the field's type is *Array*, both with_field value and logging value are merged with `concat` and `uniq`.
+If the field's type is *Array*, both with_field value and logging value are merged with `concat` and `uniq`.
+
+If the field's type is *Hash*, then values are merged recursively.
+
+```ruby
+logger.with_fields = { version: '1.1.0', user: { name: 'Taro' } }
+logger.debug(user: { age: 19 })
+```
+
+```json
+{"name":"test","hostname":"mint","pid":30182,"level":20,"time":"2017-07-22T20:52:12.332+09:00","v":0,"version":"1.1.0","msg":"No message","user":{"name":"Taro","age":19}}
+```
 
 ### Create a child logger
 
@@ -241,6 +252,8 @@ child_logger.debug('This is not outputted')
 ```
 
 If any field exists in both parent log and child log, the parent value is overridden or merged by child value.
+
+If the field's type is *Hash*, then values are merged recursively.
 
 ### Hook before logging
 

--- a/lib/ougai/logging.rb
+++ b/lib/ougai/logging.rb
@@ -120,6 +120,8 @@ module Ougai
       base_data.merge!(inferior_data) do |_, base_v, inferior_v|
         if base_v.is_a?(Array) and inferior_v.is_a?(Array)
           (inferior_v + base_v).uniq
+        elsif base_v.is_a?(Hash) and inferior_v.is_a?(Hash)
+          weak_merge!(base_v, inferior_v)
         else
           base_v
         end

--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -24,6 +24,15 @@ describe Ougai::Logging do
       expect(result[:bar]).to eq('base')
       expect(result[:baz]).to eq(['B', 'A'])
     end
+
+    it 'merges hashes recursively' do
+      result = nil
+      subject.instance_eval do
+        result = weak_merge!({ foo: { bar: { baz: 15 } } },
+                             { foo: { bar: { extra: 10 }, nested: 'string' } })
+      end
+      expect(result).to eq({ foo: { bar: { baz: 15, extra: 10 }, nested: 'string' } })
+    end
   end
 
   describe '#chain' do


### PR DESCRIPTION
Hi. 

First of all, thanks for a great gem!

When using structured logging, it is very common to have nested fields structure. Even some new standards, something like [Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/ecs-reference.html) completely relies on nested fields.

So it is very convenient to have a way to extend log events with additional fields and with child loggers, even if those fields are nested.

Something like this:

```ruby
logger = Ougai::Logger.new(STDOUT)
logger.with_fields = { process: { pid: 123 } }

module_logger = logger.child(event: { module: "core" } })

class_logger = module_logger.child(event: { dataset: "core.archive" } })

class_logger.info("Item was archived successfully", event: { action: "item-archived" })
```

and expected:
```json
{"msg": "Item was archived successfully", "process": { "pid": 123 }, "event": {"module": "core", "dataset": "core.archive", "action": "item-archived"} }
```

I don't think this change will cause any significant performance degradation. Hope it will be merged!