### PR TITLE
Support logging data with nil exception

### DIFF
--- a/lib/ougai/logger.rb
+++ b/lib/ougai/logger.rb
@@ -120,7 +120,7 @@ module Ougai
 
       if msg.nil?
         { msg: @default_message }
-      elsif ex.nil?
+      elsif ex.nil? && data.nil?
         create_item_with_1arg(msg)
       elsif data.nil?
         create_item_with_2args(msg, ex)

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -277,6 +277,24 @@ describe Ougai::Logger do
       end
     end
 
+    context 'with message, nil exception and data' do
+      it 'outputs valid' do
+        logger.send(method, log_msg, nil, something: { name: 'foo' })
+
+        expect(item).to be_log_message(log_msg, log_level)
+        expect(item).to include_data(something: { name: 'foo' })
+      end
+
+      it 'outputs valid by block' do
+        logger.send(method) do
+          [log_msg, nil, something: { name: 'foo' }]
+        end
+
+        expect(item).to be_log_message(log_msg, log_level)
+        expect(item).to include_data(something: { name: 'foo' })
+      end
+    end
+
     context 'without arguments' do
       it 'outputs only default message' do
         logger.send(method)


### PR DESCRIPTION
Prior to this PR, if a log was written with a `message` and `data` but the `exception` field was explicitly `nil`, the `data` would not be included in the log. So in the following example

```
log.error("This is a message", nil, { key: 'value' })
```

"This is a message" would appear in the log but `{ key: 'value' }` would not. I was expecting `{ key: 'value' }` to be in the log.

This PR adds support for logging the `data` field with `exception` explicitly being set to `nil`. I know this is already supported by only using 2 parameters but it seems unintuitive that a `nil` exception would cause `data` to not be logged.