### PR TITLE
rubocop recommendation for STDOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ All arguments of the `initialize` pass through itself to **::Logger**.
 require 'rubygems'
 require 'ougai'
 
-logger = Ougai::Logger.new(STDOUT)
+logger = Ougai::Logger.new($stdout)
 ```
 
 ### TRACE level


### PR DESCRIPTION
```RuboCop: Use `$stdout` instead of `STDOUT`. [Style/GlobalStdStream]```