### PR TITLE
CI: use bundler-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-      - name: Install dependencies
-        run: bundle install
+          bundler-cache: true # 'bundle install' and cache
       - name: Run tests
         run: bundle exec rspec
       - name: Code Climate Test Reporter


### PR DESCRIPTION
This PR uses the `bundler-cache` feature of the Ruby-maintained Action `ruby/setup-ruby`.

[See `ruby/setup-ruby` parameters declaration](https://github.com/ruby/setup-ruby/blob/master/action.yml) for more information.