### PR TITLE
Remove no longer working Code Climate workflow and README mentions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,3 @@ jobs:
           bundler-cache: true # 'bundle install' and cache
       - name: Run tests
         run: bundle exec rspec
-      - name: Code Climate Test Reporter
-        if: matrix.ruby-version == '3.4'
-        uses: aktions/codeclimate-test-reporter@v1
-        with:
-          codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
-          command: after-build

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Ougai
 [![Gem Version](https://badge.fury.io/rb/ougai.svg)](https://badge.fury.io/rb/ougai)
 [![document](https://img.shields.io/badge/document-2.0.0-green.svg)](http://www.rubydoc.info/gems/ougai/)
 [![CI](https://github.com/tilfin/ougai/actions/workflows/ci.yml/badge.svg)](https://github.com/tilfin/ougai/actions/workflows/ci.yml)
-[![Code Climate](https://codeclimate.com/github/tilfin/ougai/badges/gpa.svg)](https://codeclimate.com/github/tilfin/ougai)
-[![Test Coverage](https://codeclimate.com/github/tilfin/ougai/badges/coverage.svg)](https://codeclimate.com/github/tilfin/ougai/coverage)
 
 A structured logging system that is capable of handling a message, structured data, or an exception easily.
 It has JSON formatters compatible with [Bunyan](https://github.com/trentm/node-bunyan) or [pino](https://github.com/pinojs/pino) for Node.js, and a


### PR DESCRIPTION
Proposing we remove the Code Climate CI step and mentions from the README because I believe their service no longer exists. The README links go to `qlty.sh` login pages and the CI workflow simply fails. ([CI logs](https://github.com/larouxn/ougai/actions/runs/27983131030/job/82817985962))

<img width="668" height="114" alt="Screenshot From 2026-06-22 22-59-39" src="https://github.com/user-attachments/assets/f645995c-f945-427e-8a12-b43e72c28139" />
<img width="2880" height="1778" alt="image" src="https://github.com/user-attachments/assets/189f9a2f-46fb-49f9-9a7c-b5dcc0ec7a61" />
<img width="2142" height="540" alt="Screenshot From 2026-06-22 22-54-15" src="https://github.com/user-attachments/assets/52832b41-bc24-400c-97b2-0c90cc597253" />

It appears Code Climate rebranded to `qlty.sh` and changed their whole product.

https://codeclimate.com/legacy/code-climate-quality-is-now-qlty-software