### PR TITLE
Add support for and test against Ruby 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [3.0, 3.1, 3.2, 3.3, 3.4, jruby-head]
+        ruby-version: [3.0, 3.1, 3.2, 3.3, 3.4, 4.0, jruby-head]
     steps:
       - uses: actions/checkout@v7
       - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/ougai.gemspec
+++ b/ougai.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.5.0'
 
+  spec.add_dependency "logger"
+
   if RUBY_PLATFORM =~ /java/
     spec.platform = 'java'
     spec.add_dependency 'jrjackson', '~> 0.4'


### PR DESCRIPTION
### Description

Proposing we add support for and start testing against Ruby 4.

- https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/
- https://www.ruby-lang.org/en/news/2026/01/13/ruby-4-0-1-released/
- https://www.ruby-lang.org/en/news/2026/03/16/ruby-4-0-2-released/
- https://www.ruby-lang.org/en/news/2026/04/21/ruby-4-0-3-released/
- https://www.ruby-lang.org/en/news/2026/05/11/ruby-4-0-4-released/
- https://www.ruby-lang.org/en/news/2026/05/20/ruby-4-0-5-released/

### How?

1. Add Ruby `4.0` to CI Ruby matrix and use it for codecov.
2. Add `logger` gem as a dependency because it's not included by default since Ruby 4. ¹

¹ Why do we need to add `logger` as a dependency? We need to add it because it is no longer included by default in Ruby 4. Apparently also available in `jruby-head` ([CI logs](https://github.com/larouxn/ougai/actions/runs/27984042480/job/82821060749)). When one tries to run the gem such as via the test suite.

```console
ougai on  ruby_4 [$!?] via 💎 v4.0.5 
❯ bundle exec rspec spec 
Source locally installed gems is ignoring #<Bundler::StubSpecification name=racc version=1.8.1 platform=ruby> because it is missing extensions
/home/larouxn/.gem/ruby/4.0.5/gems/simplecov-html-0.10.2/lib/simplecov-html.rb:2: warning: CGI library is removed from Ruby 4.0. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
If you need to use the full features of CGI library, Please install cgi gem.
/home/larouxn/src/github.com/larouxn/ougai/lib/ougai.rb:1: warning: logger used to be loaded from the standard library, but is not part of the default gems since Ruby 4.0.0.
You can add logger to your Gemfile or gemspec to fix this error.

An error occurred while loading ./spec/child_logger_spec.rb. - Did you mean?
                    rspec ./spec/logger_spec.rb

Failure/Error: require 'logger'

LoadError:
  cannot load such file -- logger
# ./lib/ougai.rb:1:in '<top (required)>'
# ./spec/spec_helper.rb:8:in '<top (required)>'
# ./spec/child_logger_spec.rb:1:in '<top (required)>'
```

It blows up when you don't include `logger` gem as a dependency while on Ruby 4 due to this line:

https://github.com/tilfin/ougai/blob/397d07713c93f92a125c7ef6915f23c07df7db63/lib/ougai.rb#L1

### Testing

All Ruby versions passing all tests. ([CI logs](https://github.com/larouxn/ougai/actions/runs/27983131030/job/82817985962))
<img width="2880" height="1768" alt="Screenshot From 2026-06-22 23-12-33" src="https://github.com/user-attachments/assets/74aa609a-f9d5-4da5-b7f6-58c88a6bb68d" />

Note, this PR needs the following fixes to get to green CI status.
- https://github.com/tilfin/ougai/pull/141 (fixes the CI failure above)
- https://github.com/tilfin/ougai/pull/142