### PR TITLE
Fix Node 20 deprecation warnings in CI with modern actions/checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         ruby-version: [3.0, 3.1, 3.2, 3.3, 3.4, jruby-head]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
### Description

Proposing we upgrade to latest `actions/checkout` to resolve the following deprecation warnings in CI.

Release notes
- https://github.com/actions/checkout/releases/tag/v5.0.0 (resolves the deprecation warnings)
- https://github.com/actions/checkout/releases/tag/v6.0.0
- https://github.com/actions/checkout/releases/tag/v7.0.0

### Testing

Without this PR's change i.e. `main`, many warnings. ([CI logs](https://github.com/larouxn/ougai/actions/runs/27984601374))
<img width="2880" height="1768" alt="Screenshot From 2026-06-22 23-18-25" src="https://github.com/user-attachments/assets/b91b20e2-0871-4938-b475-6a018de4065f" />

With this PR's change, no more deprecation warnings. ([CI logs](https://github.com/larouxn/ougai/actions/runs/27984814252))
<img width="2880" height="1768" alt="Screenshot From 2026-06-22 23-21-37" src="https://github.com/user-attachments/assets/9d550d6b-06ac-4b8a-a643-35b95863210e" />